### PR TITLE
refacto(ui): Change system of generation main ui

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ pub mod app;
 pub mod cli;
 pub mod components;
 pub mod config;
+pub mod main_layout;
 pub mod mode;
 pub mod models;
 pub mod style;

--- a/src/main_layout.rs
+++ b/src/main_layout.rs
@@ -23,6 +23,12 @@ pub struct MainLayout {
     pub status_chunk: Option<Rc<[Rect]>>,
 }
 
+impl Default for MainLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MainLayout {
     pub fn new() -> MainLayout {
         MainLayout {

--- a/src/main_layout.rs
+++ b/src/main_layout.rs
@@ -1,0 +1,105 @@
+use crate::mode::Mode;
+use ratatui::prelude::Constraint;
+use ratatui::prelude::Direction;
+use ratatui::prelude::Layout;
+use ratatui::prelude::Rect;
+use ratatui::Frame;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub enum Chunk {
+    Context(usize),
+    Command,
+    Table,
+    Status,
+}
+
+pub struct MainLayout {
+    pub tui_size: Option<Rc<RefCell<Rect>>>,
+    pub main_chunk: Option<Rc<[Rect]>>,
+    pub context_chunk: Option<Rc<[Rect]>>,
+    pub command_chunk: Option<Rc<[Rect]>>,
+    pub table_chunk: Option<Rc<[Rect]>>,
+    pub status_chunk: Option<Rc<[Rect]>>,
+}
+
+impl MainLayout {
+    pub fn new() -> MainLayout {
+        MainLayout {
+            tui_size: None,
+            main_chunk: None,
+            context_chunk: None,
+            command_chunk: None,
+            table_chunk: None,
+            status_chunk: None,
+        }
+    }
+
+    pub fn get_constraints(&self, mode: &Mode) -> [Constraint; 4] {
+        [
+            Constraint::Length(6),
+            if mode == &Mode::Search || mode == &Mode::Command {
+                Constraint::Length(3)
+            } else {
+                Constraint::Percentage(0)
+            },
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ]
+    }
+
+    pub fn set_tui_size(&mut self, tui_size: Rc<RefCell<Rect>>) {
+        self.tui_size = Some(tui_size);
+    }
+
+    pub fn set_main_layout(&mut self, mode: &Mode) {
+        if let Some(tui_size) = &self.tui_size {
+            self.main_chunk = Some(
+                Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints(self.get_constraints(mode))
+                    .margin(1)
+                    .split(*tui_size.borrow_mut()),
+            );
+        }
+        if let Some(main_chunk) = &self.main_chunk {
+            self.context_chunk = Some(
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(vec![
+                        Constraint::Length(50),
+                        Constraint::Fill(1),
+                        Constraint::Length(22),
+                    ])
+                    .split(main_chunk[0]),
+            );
+            self.command_chunk = Some(
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(vec![Constraint::Percentage(100)])
+                    .split(main_chunk[1]),
+            );
+            self.table_chunk = Some(
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(vec![Constraint::Percentage(100)])
+                    .split(main_chunk[2]),
+            );
+            self.status_chunk = Some(
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(vec![Constraint::Percentage(100)])
+                    .split(main_chunk[3]),
+            );
+        }
+    }
+
+    pub fn get_chunk(&self, chunk: Chunk) -> Rect {
+        match chunk {
+            Chunk::Context(area) => self.context_chunk.clone().unwrap()[area],
+            Chunk::Command => self.command_chunk.clone().unwrap()[0],
+            Chunk::Table => self.table_chunk.clone().unwrap()[0],
+            Chunk::Status => self.status_chunk.clone().unwrap()[0],
+        }
+    }
+}

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -15,9 +15,17 @@ pub enum Mode {
     Command,
 }
 
+pub type RefreshLayoutFnType = Option<RefCell<Box<dyn FnMut(Mode)>>>;
+
 pub struct ObservableMode {
     mode: Mode,
-    refresh_layout_fn: Option<RefCell<Box<dyn FnMut(Mode)>>>,
+    refresh_layout_fn: RefreshLayoutFnType,
+}
+
+impl Default for ObservableMode {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ObservableMode {

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,3 +1,7 @@
+use ratatui::prelude::Rect;
+use std::borrow::Borrow;
+use std::cell::RefCell;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -9,4 +13,36 @@ pub enum Mode {
     Log,
     Code,
     Command,
+}
+
+pub struct ObservableMode {
+    mode: Mode,
+    refresh_layout_fn: Option<RefCell<Box<dyn FnMut(Mode)>>>,
+}
+
+impl ObservableMode {
+    pub fn new() -> Self {
+        ObservableMode {
+            mode: Mode::DagRun,
+            refresh_layout_fn: None,
+        }
+    }
+
+    pub fn get(&self) -> Mode {
+        self.mode
+    }
+
+    pub fn set_refresh_layout_fn<F>(&mut self, callback: F)
+    where
+        F: FnMut(Mode) + 'static,
+    {
+        self.refresh_layout_fn = Some(RefCell::new(Box::new(callback)));
+    }
+
+    pub fn set_mode(&mut self, mode: Mode) {
+        self.mode = mode;
+        if let Some(refresh_fn) = &self.refresh_layout_fn {
+            (refresh_fn.borrow_mut())(mode);
+        }
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,3 +1,4 @@
+use crate::mode::Mode;
 use std::{
     ops::{Deref, DerefMut},
     time::Duration,
@@ -13,7 +14,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 use futures::{FutureExt, StreamExt};
-use ratatui::backend::CrosstermBackend as Backend;
+use ratatui::{backend::CrosstermBackend as Backend, layout::Constraint};
 use serde::{Deserialize, Serialize};
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
@@ -225,6 +226,19 @@ impl Tui {
 
     pub async fn next(&mut self) -> Option<Event> {
         self.event_rx.recv().await
+    }
+
+    pub fn get_main_constraint(&self, mode: Mode) -> [Constraint; 4] {
+        [
+            Constraint::Length(6),
+            if mode == Mode::Search || mode == Mode::Command {
+                Constraint::Length(3)
+            } else {
+                Constraint::Percentage(0)
+            },
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ]
     }
 }
 


### PR DESCRIPTION
This PR aims to :
 - Output the layout into a custom struct
 - Creation of an observation pattern for the mode, so that each time the mode is modified, the ui is regenerated

To avoid generating the layout each time the tui is rendered, we have an observation structure which will launch the layout generation function, and to avoid having to clone the main layout several times we go through a reference counter as well as a RefCell to have mutability from the inside, so Iican access the main layout with a reference that points to the main object. 